### PR TITLE
Correct inverted environment/config.js -> config/environment.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ember install ember-new-relic
 
 ### Basic Usage
 
-Add your `applicationId` and `licenseKey` to `environment/config.js`:
+Add your `applicationId` and `licenseKey` to `config/environment.js`:
 
 ```js
 /* config/environment.js */


### PR DESCRIPTION
Just a small change to a typo in the README
