### PR TITLE
Propose a way to ignore current unwanted TransitionAborted raised by Ember 2.X

### DIFF
--- a/addon/instance-initializers/new-relic.js
+++ b/addon/instance-initializers/new-relic.js
@@ -7,7 +7,17 @@ export function initialize() {
     return;
   }
 
+  function mustIgnoreError(error) {
+    // Ember 2.X seems to not catch `TransitionAborted` errors caused by regular redirects. We don't want these errors to show up in NewRelic so we have to filter them ourselfs.
+    // Once the issue https://github.com/emberjs/ember.js/issues/12505 is resolved we can remove this ignored error.
+    return (error.name === 'TransitionAborted');
+  }
+
   function handleError(error) {
+    if (mustIgnoreError(error)) {
+      return;
+    }
+
     try {
       NREUM.noticeError(error);
     } catch(e) {

--- a/tests/acceptance/new-relic-browser-test.js
+++ b/tests/acceptance/new-relic-browser-test.js
@@ -10,7 +10,7 @@ test('Loading New Relic Browser', function(assert) {
   andThen(function() {
     var newRelic = window.NREUM;
 
-    assert.expect(6);
+    assert.expect(8);
 
     assert.ok(newRelic,
       'The New Relic object (NREUM) should be added to the window');
@@ -29,9 +29,15 @@ test('Loading New Relic Browser', function(assert) {
       assert.ok(error instanceof Error,
         'noticeError should receive an error object');
 
+      assert.ok(error.name !== 'TransitionAborted',
+        'noticeError should not be called by Ember.onerror on TransitionAborted errors.');
     };
 
     Ember.onerror(new Error('Awh crap'));
+
+    const transitionError = new Error('Ember Transition Aborted Test');
+    transitionError.name = "TransitionAborted";
+    Ember.onerror(transitionError);
 
     Ember.Logger.error('Whoops', 'We done messed up', {});
 


### PR DESCRIPTION
This is a quick and dirty proposal to not log to New Relic errors that aren't desired. In the current context, there is an issue where TransitionAborted errors that are regular redirects are reported and causing a lot of noise into New Relic analytics tooling.

See https://github.com/emberjs/ember.js/issues/12505 for more details on the current issue in Ember.

This proposal is inspired by the change made for Sentry by this commit: https://github.com/stravid/datsu-frontend/commit/e4d8d9adc496dff4a310f47fd95f050a71d2c196