### PR TITLE
Only include new relic script in browser builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ module.exports = {
     // Execute the included method of the parent class.
     this._super.included.apply(this, arguments);
 
+    // Don't include the new relic script if running in a fastboot environment.
+    if (process.env.EMBER_CLI_FASTBOOT) return;
+
     var env  = process.env.EMBER_ENV;
     var options = (this.app && this.app.options && this.app.options['ember-new-relic']) || {};
 


### PR DESCRIPTION
The new relic javascript that gets added to vendor.js relies on `window` being present, so it errors out in fastboot environments. This makes sure new relic is only included in browser builds.