### PR TITLE
still call original error handlers

### DIFF
--- a/addon/instance-initializers/new-relic.js
+++ b/addon/instance-initializers/new-relic.js
@@ -42,14 +42,14 @@ export function initialize() {
       _oldOnerror.call(this, error);
     }
     handleError(error);
-  }
+  };
 
   Ember.RSVP.on('error', handleError);
 
   const _oldLoggerError = Ember.Logger.error;
 
   Ember.Logger.error = function(...args) {
-    const [message, cause, stack] = args;
+    const [, cause, stack] = args;
     if (Ember.typeOf(_oldLoggerError) === 'function') {
       _oldLoggerError.call(Ember.Logger, ...args);
     }

--- a/addon/instance-initializers/new-relic.js
+++ b/addon/instance-initializers/new-relic.js
@@ -35,11 +35,24 @@ export function initialize() {
     return error;
   }
 
-  Ember.onerror = handleError;
+  const _oldOnerror = Ember.onerror;
+
+  Ember.onerror = function(error) {
+    if (Ember.typeOf(_oldOnerror) === 'function') {
+      _oldOnerror.call(this, error);
+    }
+    handleError(error);
+  }
 
   Ember.RSVP.on('error', handleError);
 
-  Ember.Logger.error = function(message, cause, stack) {
+  const _oldLoggerError = Ember.Logger.error;
+
+  Ember.Logger.error = function(...args) {
+    const [message, cause, stack] = args;
+    if (Ember.typeOf(_oldLoggerError) === 'function') {
+      _oldLoggerError.call(Ember.Logger, ...args);
+    }
     handleError(generateError(cause, stack));
   };
 }


### PR DESCRIPTION
e.g. a user may also be using ember-cli-sentry or any other (homebrewed) error handling solution