### PR TITLE
Fix error messages in console

### DIFF
--- a/addon/instance-initializers/new-relic.js
+++ b/addon/instance-initializers/new-relic.js
@@ -28,9 +28,7 @@ export function initialize() {
       // Ignore
     }
 
-    if (error && error.stack) {
-      console.error(error.stack);
-    }
+    console.error(error);
   }
 
   function generateError(cause, stack) {
@@ -45,8 +43,8 @@ export function initialize() {
 
   Ember.RSVP.on('error', handleError);
 
-  Ember.Logger.error = function(message, cause, stack) {
-    handleError(generateError(cause, stack));
+  Ember.Logger.error = function(...messages) {
+    handleError(generateError(messages.join(' ')));
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "dependencies": {
     "broccoli-file-creator": "^1.1.1",
-    "broccoli-merge-trees": "^1.1.4",
+    "broccoli-merge-trees": "^1.2.4",
     "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {

--- a/tests/acceptance/new-relic-browser-test.js
+++ b/tests/acceptance/new-relic-browser-test.js
@@ -49,9 +49,10 @@ test('console.error from Ember.Logger.error correctly shows messages', function(
 
   andThen(function() {
 
-    console.error = function(message) {
-      assert.ok(
-        message.toString().includes('Whoops We done messed up'),
+    console.error = function (message) {
+      assert.strictEqual(
+        message.toString(),
+        'Error: Whoops We done messed up',
         'Shows messages space-separated'
       );
     };

--- a/tests/acceptance/new-relic-browser-test.js
+++ b/tests/acceptance/new-relic-browser-test.js
@@ -43,3 +43,19 @@ test('Loading New Relic Browser', function(assert) {
 
   });
 });
+
+test('console.error from Ember.Logger.error correctly shows messages', function(assert) {
+  visit('/');
+
+  andThen(function() {
+
+    console.error = function(message) {
+      assert.ok(
+        message.toString().includes('Whoops We done messed up'),
+        'Shows messages space-separated'
+      );
+    };
+
+    Ember.Logger.error('Whoops', 'We done messed up');
+  });
+});


### PR DESCRIPTION
Since we installed `ember-new-relic`, some of our errors have been coming through to the console without a message.  This PR fixes this.  In particular, I identified and fixed 2 issues:

#### Issue 1. the `error.stack` was being passed to the console.  Should be the entire `error` object.

##### Before `ember-new-relic`

![image](https://cloud.githubusercontent.com/assets/11724146/23566989/dac0d2f8-0019-11e7-9cd9-907cb4a831d3.png)

##### After `ember-new-relic`

`console.error(error.stack);`

![image](https://cloud.githubusercontent.com/assets/11724146/23567024/04da2260-001a-11e7-8fa1-1b384933131d.png)

##### Now

`console.error(error);`

![image](https://cloud.githubusercontent.com/assets/11724146/23566955/c0898434-0019-11e7-9c82-eb2157121601.png)



#### Issue 2. using `Ember.Logger.error` was omitting the `message` ([issue](https://github.com/sir-dunxalot/ember-new-relic/issues/11#issuecomment-276158332))

##### Before `ember-new-relic`

![image](https://cloud.githubusercontent.com/assets/11724146/23567277/299f7216-001b-11e7-9a16-61dbc7d3a339.png)

##### After `ember-new-relic`

```
Ember.Logger.error = function(message, cause, stack) {
  handleError(generateError(cause, stack));
};
```

![image](https://cloud.githubusercontent.com/assets/11724146/23567108/54b69818-001a-11e7-8ce8-bc0e2dbd94fd.png)

##### Now

```
Ember.Logger.error = function(...messages) {
  handleError(generateError(messages.join(' ')));
};
```

![image](https://cloud.githubusercontent.com/assets/11724146/23567232/f8e154dc-001a-11e7-8991-643df2b40731.png)
