### PR TITLE
Don't show lack of properties warning if no applicationId

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ module.exports = {
     var outputPath = this.outputPath = 'outputPath' in options ? options.outputPath : this.outputPath;
     var isValidNewRelicConfig = this.isValidNewRelicConfig = newRelicConfig.applicationID && newRelicConfig.licenseKey;
 
-    if (!isValidNewRelicConfig) {
+    // Don't show the warning if they didn't provide an applicationID
+    var showLackOfPropertiesWarning = newRelicConfig.applicationID && !isValidNewRelicConfig;
+    if (showLackOfPropertiesWarning) {
       this._writeWarnLine('New Relic config needs `applicationId` and `licenseKey` properties in order to output New Relic script.');
     }
 


### PR DESCRIPTION
Addresses https://github.com/sir-dunxalot/ember-new-relic/issues/16

According to the docs, you can disable New Relic for a certain environment by omitting the applicationId. Therefore, we shouldn't show the lack of properties warning if they omit the applicationId.

![image](https://cloud.githubusercontent.com/assets/11724146/25047958/6691c98a-20ff-11e7-96ed-a5658b84330d.png)
